### PR TITLE
Remove `undefined` from generated rrule string when until.local is unset

### DIFF
--- a/packages/ts-ics/src/lib/generate/recurrenceRule.ts
+++ b/packages/ts-ics/src/lib/generate/recurrenceRule.ts
@@ -35,15 +35,16 @@ export const generateIcsRecurrenceRule = (value: RecurrenceRule) => {
       value.until && {
         key: "UNTIL",
         value: `${
-          value.until.local &&
-          `${generateIcsOptions(
-            compact([
-              {
-                key: "TZID",
-                value: value.until.local.timezone,
-              },
-            ])
-          )}=`
+          value.until.local
+            ? `${generateIcsOptions(
+                compact([
+                  {
+                    key: 'TZID',
+                    value: value.until.local.timezone,
+                  },
+                ])
+              )}=`
+            : ''
         }${value.until.date}`,
       },
       value.workweekStart && { key: "WKST", value: value.workweekStart },


### PR DESCRIPTION
I noticed that the conditional logic is faulty and leads to the `UNTIL` key in the RRULE string contains "undefined" if `until.local` is not set:

Current (faulty):
`RRULE:BYDAY=TH;FREQ=WEEKLY;INTERVAL=1;UNTIL=undefinedThu Dec 19 2024 17:00:00 GMT+0100 (Central European Standard Time)`

After correction:
`RRULE:BYDAY=TH;FREQ=WEEKLY;INTERVAL=1;UNTIL=Thu Dec 19 2024 17:00:00 GMT+0100 (Central European Standard Time)`