### PR TITLE
add support for X-WR-CALNAME

### DIFF
--- a/packages/ts-ics/src/constants/keys/calendar.ts
+++ b/packages/ts-ics/src/constants/keys/calendar.ts
@@ -1,19 +1,22 @@
-export const VCALENDAR_KEYS = ["VERSION", "METHOD", "PRODID"] as const;
+export const VCALENDAR_KEYS = ["VERSION", "METHOD", "PRODID", "X-WR-CALNAME"] as const;
 export type VCalendarKeys = typeof VCALENDAR_KEYS;
 export type VCalendarKey = VCalendarKeys[number];
 
-export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId"] as const;
+export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId", "name"] as const;
 
 export type VCalendarObjectKeys = typeof VCALENDAR_OBJECT_KEYS;
 export type VCalendarObjectKey = VCalendarObjectKeys[number];
 
-export const VCALENDAR_TO_OBJECT_KEYS: Record<
-  VCalendarKey,
-  VCalendarObjectKey
-> = { METHOD: "method", PRODID: "prodId", VERSION: "version" };
+export const VCALENDAR_TO_OBJECT_KEYS: Record<VCalendarKey, VCalendarObjectKey> = {
+	METHOD: "method",
+	PRODID: "prodId",
+	VERSION: "version",
+	"X-WR-CALNAME": "name",
+};
 
 export const VCALENDAR_TO_KEYS: Record<VCalendarObjectKey, VCalendarKey> = {
-  method: "METHOD",
-  prodId: "PRODID",
-  version: "VERSION",
+	method: "METHOD",
+	prodId: "PRODID",
+	version: "VERSION",
+	name: "X-WR-CALNAME",
 };

--- a/packages/ts-ics/src/constants/keys/calendar.ts
+++ b/packages/ts-ics/src/constants/keys/calendar.ts
@@ -2,7 +2,7 @@ export const VCALENDAR_KEYS = ["VERSION", "METHOD", "PRODID", "X-WR-CALNAME"] as
 export type VCalendarKeys = typeof VCALENDAR_KEYS;
 export type VCalendarKey = VCalendarKeys[number];
 
-export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId", "calname"] as const;
+export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId", "name"] as const;
 
 export type VCalendarObjectKeys = typeof VCALENDAR_OBJECT_KEYS;
 export type VCalendarObjectKey = VCalendarObjectKeys[number];
@@ -11,12 +11,12 @@ export const VCALENDAR_TO_OBJECT_KEYS: Record<VCalendarKey, VCalendarObjectKey> 
 	METHOD: "method",
 	PRODID: "prodId",
 	VERSION: "version",
-	"X-WR-CALNAME": "calname",
+	"X-WR-CALNAME": "name",
 };
 
 export const VCALENDAR_TO_KEYS: Record<VCalendarObjectKey, VCalendarKey> = {
 	method: "METHOD",
 	prodId: "PRODID",
 	version: "VERSION",
-	calname: "X-WR-CALNAME",
+	name: "X-WR-CALNAME",
 };

--- a/packages/ts-ics/src/constants/keys/calendar.ts
+++ b/packages/ts-ics/src/constants/keys/calendar.ts
@@ -2,7 +2,7 @@ export const VCALENDAR_KEYS = ["VERSION", "METHOD", "PRODID", "X-WR-CALNAME"] as
 export type VCalendarKeys = typeof VCALENDAR_KEYS;
 export type VCalendarKey = VCalendarKeys[number];
 
-export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId", "name"] as const;
+export const VCALENDAR_OBJECT_KEYS = ["version", "method", "prodId", "calname"] as const;
 
 export type VCalendarObjectKeys = typeof VCALENDAR_OBJECT_KEYS;
 export type VCalendarObjectKey = VCalendarObjectKeys[number];
@@ -11,12 +11,12 @@ export const VCALENDAR_TO_OBJECT_KEYS: Record<VCalendarKey, VCalendarObjectKey> 
 	METHOD: "method",
 	PRODID: "prodId",
 	VERSION: "version",
-	"X-WR-CALNAME": "name",
+	"X-WR-CALNAME": "calname",
 };
 
 export const VCALENDAR_TO_KEYS: Record<VCalendarObjectKey, VCalendarKey> = {
 	method: "METHOD",
 	prodId: "PRODID",
 	version: "VERSION",
-	name: "X-WR-CALNAME",
+	calname: "X-WR-CALNAME",
 };

--- a/packages/ts-ics/src/types/calendar.ts
+++ b/packages/ts-ics/src/types/calendar.ts
@@ -14,6 +14,7 @@ export type VCalendar = {
   method?: VCalenderMethod | string;
   timezones?: VTimezone[];
   events?: VEvent[];
+  name?: string;
 };
 
 export const zVCalendar: z.ZodType<VCalendar> = z.object({
@@ -22,4 +23,5 @@ export const zVCalendar: z.ZodType<VCalendar> = z.object({
   method: z.union([z.enum(zVCalendarMethods), z.string()]).optional(),
   timezones: z.array(zVTimezone).optional(),
   events: z.array(zVEvent).optional(),
+  name: z.string(),
 });

--- a/packages/ts-ics/src/types/calendar.ts
+++ b/packages/ts-ics/src/types/calendar.ts
@@ -14,7 +14,7 @@ export type VCalendar = {
 	method?: VCalenderMethod | string;
 	timezones?: VTimezone[];
 	events?: VEvent[];
-	calname?: string;
+	name?: string;
 };
 
 export const zVCalendar: z.ZodType<VCalendar> = z.object({
@@ -23,5 +23,5 @@ export const zVCalendar: z.ZodType<VCalendar> = z.object({
 	method: z.union([z.enum(zVCalendarMethods), z.string()]).optional(),
 	timezones: z.array(zVTimezone).optional(),
 	events: z.array(zVEvent).optional(),
-	calname: z.string().optional(),
+	name: z.string().optional(),
 });

--- a/packages/ts-ics/src/types/calendar.ts
+++ b/packages/ts-ics/src/types/calendar.ts
@@ -9,19 +9,19 @@ export type VCalendarMethods = typeof zVCalendarMethods;
 export type VCalenderMethod = VCalendarMethods[number];
 
 export type VCalendar = {
-  version: "2.0";
-  prodId: string;
-  method?: VCalenderMethod | string;
-  timezones?: VTimezone[];
-  events?: VEvent[];
-  name?: string;
+	version: "2.0";
+	prodId: string;
+	method?: VCalenderMethod | string;
+	timezones?: VTimezone[];
+	events?: VEvent[];
+	calname?: string;
 };
 
 export const zVCalendar: z.ZodType<VCalendar> = z.object({
-  version: z.literal("2.0"),
-  prodId: z.string(),
-  method: z.union([z.enum(zVCalendarMethods), z.string()]).optional(),
-  timezones: z.array(zVTimezone).optional(),
-  events: z.array(zVEvent).optional(),
-  name: z.string(),
+	version: z.literal("2.0"),
+	prodId: z.string(),
+	method: z.union([z.enum(zVCalendarMethods), z.string()]).optional(),
+	timezones: z.array(zVTimezone).optional(),
+	events: z.array(zVEvent).optional(),
+	calname: z.string().optional(),
 });


### PR DESCRIPTION
It would be nice to add a calendar name via generateIcsCalendar(). While it is not a required field, it is a great user experience when adding/subscribing to a calendar. This way the user does not have to manually enter a calendar name.