### PR TITLE
Correctly handle RECURRENCE-ID

### DIFF
--- a/packages/ts-ics/src/lib/generate/event.ts
+++ b/packages/ts-ics/src/lib/generate/event.ts
@@ -9,6 +9,7 @@ import type {
   IcsEvent,
   IcsDuration,
   IcsRecurrenceRule,
+  IcsRecurrenceId,
 } from "@/types";
 import type { IcsOrganizer } from "@/types/organizer";
 
@@ -82,6 +83,11 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
 
     if (key === "recurrenceRule") {
       icsString += generateIcsRecurrenceRule(value as IcsRecurrenceRule);
+      return;
+    }
+
+    if (key === "recurrenceId") {
+      icsString += generateIcsTimeStamp("RECURRENCE-ID", (value as IcsRecurrenceId).value);
       return;
     }
 


### PR DESCRIPTION
Updated event generation to generate valid recurrence-id dates. This PR addresses an issue where certain RECURRENCE-IDs (from Google calendar) are generated as `RECURRENCE-ID:[object Object]`. With this small addition, the dates are properly handled regardless of format using the `generateIcsTimeStamp()` function.