### PR TITLE
Strip Z from timezone and apply offset to local timezone generation

### DIFF
--- a/.changeset/slow-groups-tickle.md
+++ b/.changeset/slow-groups-tickle.md
@@ -1,0 +1,5 @@
+---
+"ts-ics": patch
+---
+
+Strip Z from timezone and apply offset to local timezone generation #166

--- a/packages/ts-ics/src/lib/generate/calendar.ts
+++ b/packages/ts-ics/src/lib/generate/calendar.ts
@@ -54,7 +54,10 @@ export const generateIcsCalendar = <T extends NonStandardValuesGeneric>(
 
   if (calendar.events && calendar.events.length > 0) {
     calendar.events.forEach((event) => {
-      icsString += generateIcsEvent(event, { skipFormatLines: true });
+      icsString += generateIcsEvent(event, {
+        skipFormatLines: true,
+        timezones: calendar.timezones,
+      });
     });
   }
 

--- a/packages/ts-ics/src/lib/generate/date.ts
+++ b/packages/ts-ics/src/lib/generate/date.ts
@@ -1,4 +1,6 @@
-import { isDate } from "date-fns";
+import type { DateObjectType, DateObjectTzProps, IcsTimezone } from "@/types";
+import { getTimezoneObjectOffset } from "@/utils";
+import { addMilliseconds, getHours, isDate } from "date-fns";
 
 export const generateIcsDate = (date: Date) => {
   if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
@@ -12,7 +14,7 @@ export const generateIcsDate = (date: Date) => {
   return `${year}${month}${d}`;
 };
 
-export const generateIcsDateTime = (date: Date) => {
+export const generateIcsUtcDateTime = (date: Date) => {
   if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
 
   const isoDate = date.toISOString();
@@ -24,5 +26,36 @@ export const generateIcsDateTime = (date: Date) => {
   const minutes = isoDate.slice(14, 16);
   const seconds = isoDate.slice(17, 19);
 
+  console.log(getHours(date), hour);
+
   return `${year}${month}${d}T${hour}${minutes}${seconds}Z`;
+};
+
+export const generateIcsLocalDateTime = (
+  local: DateObjectTzProps,
+  timezones?: IcsTimezone[]
+): string => {
+  const date = local.date;
+
+  if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
+
+  const utcDate = new Date(date.toISOString());
+  console.log("utcDate", utcDate);
+
+  const timezone = getTimezoneObjectOffset(utcDate, local.timezone, timezones);
+
+  const dateWithCorrectedTimeZone = timezone
+    ? addMilliseconds(utcDate, timezone.milliseconds)
+    : utcDate;
+
+  const isoDate = dateWithCorrectedTimeZone.toISOString();
+
+  const year = isoDate.slice(0, 4);
+  const month = isoDate.slice(5, 7);
+  const d = isoDate.slice(8, 10);
+  const hour = isoDate.slice(11, 13);
+  const minutes = isoDate.slice(14, 16);
+  const seconds = isoDate.slice(17, 19);
+
+  return `${year}${month}${d}T${hour}${minutes}${seconds}`;
 };

--- a/packages/ts-ics/src/lib/generate/date.ts
+++ b/packages/ts-ics/src/lib/generate/date.ts
@@ -1,6 +1,6 @@
-import type { DateObjectType, DateObjectTzProps, IcsTimezone } from "@/types";
+import type { DateObjectTzProps, IcsTimezone } from "@/types";
 import { getTimezoneObjectOffset } from "@/utils";
-import { addMilliseconds, getHours, isDate } from "date-fns";
+import { addMilliseconds, isDate } from "date-fns";
 
 export const generateIcsDate = (date: Date) => {
   if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
@@ -17,18 +17,7 @@ export const generateIcsDate = (date: Date) => {
 export const generateIcsUtcDateTime = (date: Date) => {
   if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
 
-  const isoDate = date.toISOString();
-
-  const year = isoDate.slice(0, 4);
-  const month = isoDate.slice(5, 7);
-  const d = isoDate.slice(8, 10);
-  const hour = isoDate.slice(11, 13);
-  const minutes = isoDate.slice(14, 16);
-  const seconds = isoDate.slice(17, 19);
-
-  console.log(getHours(date), hour);
-
-  return `${year}${month}${d}T${hour}${minutes}${seconds}Z`;
+  return generateIcsDateTime(date);
 };
 
 export const generateIcsLocalDateTime = (
@@ -40,7 +29,6 @@ export const generateIcsLocalDateTime = (
   if (!isDate(date)) throw Error(`Incorrect date object: ${date}`);
 
   const utcDate = new Date(date.toISOString());
-  console.log("utcDate", utcDate);
 
   const timezone = getTimezoneObjectOffset(utcDate, local.timezone, timezones);
 
@@ -48,7 +36,11 @@ export const generateIcsLocalDateTime = (
     ? addMilliseconds(utcDate, timezone.milliseconds)
     : utcDate;
 
-  const isoDate = dateWithCorrectedTimeZone.toISOString();
+  return generateIcsDateTime(dateWithCorrectedTimeZone, true);
+};
+
+const generateIcsDateTime = (date: Date, isLocal?: boolean): string => {
+  const isoDate = date.toISOString();
 
   const year = isoDate.slice(0, 4);
   const month = isoDate.slice(5, 7);
@@ -57,5 +49,5 @@ export const generateIcsLocalDateTime = (
   const minutes = isoDate.slice(14, 16);
   const seconds = isoDate.slice(17, 19);
 
-  return `${year}${month}${d}T${hour}${minutes}${seconds}`;
+  return `${year}${month}${d}T${hour}${minutes}${seconds}${isLocal ? "" : "Z"}`;
 };

--- a/packages/ts-ics/src/lib/generate/event.ts
+++ b/packages/ts-ics/src/lib/generate/event.ts
@@ -10,6 +10,7 @@ import type {
   IcsDuration,
   IcsRecurrenceRule,
   IcsRecurrenceId,
+  IcsTimezone,
 } from "@/types";
 import type { IcsOrganizer } from "@/types/organizer";
 
@@ -38,6 +39,7 @@ import { generateIcsRecurrenceId } from "./recurrenceId";
 type GenerateIcsEventOptions<T extends NonStandardValuesGeneric> = {
   skipFormatLines?: boolean;
   nonStandard?: GenerateNonStandardValues<T>;
+  timezones?: IcsTimezone[];
 };
 
 export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
@@ -68,7 +70,12 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
     if (value === undefined || value === null) return;
 
     if (objectKeyIsTimeStamp(key)) {
-      icsString += generateIcsTimeStamp(icsKey, value as IcsDateObject);
+      icsString += generateIcsTimeStamp(
+        icsKey,
+        value as IcsDateObject,
+        undefined,
+        { timezones: options?.timezones }
+      );
       return;
     }
 
@@ -106,7 +113,9 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
     }
 
     if (key === "recurrenceId") {
-      icsString += generateIcsRecurrenceId(value as IcsRecurrenceId);
+      icsString += generateIcsRecurrenceId(value as IcsRecurrenceId, {
+        timezones: options?.timezones,
+      });
       return;
     }
 
@@ -127,7 +136,9 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
 
   if (event.exceptionDates && event.exceptionDates.length > 0) {
     event.exceptionDates.forEach((exceptionDate) => {
-      icsString += generateIcsExceptionDate(exceptionDate, "EXDATE");
+      icsString += generateIcsExceptionDate(exceptionDate, "EXDATE", {
+        timezones: options?.timezones,
+      });
     });
   }
 

--- a/packages/ts-ics/src/lib/generate/event.ts
+++ b/packages/ts-ics/src/lib/generate/event.ts
@@ -74,7 +74,7 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
         icsKey,
         value as IcsDateObject,
         undefined,
-        { timezones: options?.timezones }
+        { timezones: options?.timezones, forceUtc: key === "stamp" }
       );
       return;
     }

--- a/packages/ts-ics/src/lib/generate/exceptionDate.ts
+++ b/packages/ts-ics/src/lib/generate/exceptionDate.ts
@@ -1,7 +1,13 @@
 import type { IcsExceptionDate } from "@/types/exceptionDate";
 import { generateIcsTimeStamp } from "./timeStamp";
+import type { IcsTimezone } from "@/types";
+
+type GenerateIcsExceptionDateOptions = {
+  timezones?: IcsTimezone[];
+};
 
 export const generateIcsExceptionDate = (
   exceptionDate: IcsExceptionDate,
-  key: string
-) => generateIcsTimeStamp(key, exceptionDate);
+  key: string,
+  options?: GenerateIcsExceptionDateOptions
+) => generateIcsTimeStamp(key, exceptionDate, undefined, options);

--- a/packages/ts-ics/src/lib/generate/recurrenceId.ts
+++ b/packages/ts-ics/src/lib/generate/recurrenceId.ts
@@ -1,8 +1,15 @@
-import type { IcsRecurrenceId } from "@/types";
+import type { IcsRecurrenceId, IcsTimezone } from "@/types";
 
 import { generateIcsTimeStamp } from "./timeStamp";
 
-export const generateIcsRecurrenceId = (value: IcsRecurrenceId) => {
+type GenerateIcsExceptionDateOptions = {
+  timezones?: IcsTimezone[];
+};
+
+export const generateIcsRecurrenceId = (
+  value: IcsRecurrenceId,
+  options?: GenerateIcsExceptionDateOptions
+) => {
   let icsString = "";
 
   icsString += generateIcsTimeStamp(
@@ -15,7 +22,8 @@ export const generateIcsRecurrenceId = (value: IcsRecurrenceId) => {
             value: value.range,
           },
         ]
-      : undefined
+      : undefined,
+    options
   );
 
   return icsString;

--- a/packages/ts-ics/src/lib/generate/recurrenceRule.ts
+++ b/packages/ts-ics/src/lib/generate/recurrenceRule.ts
@@ -3,7 +3,7 @@ import type { IcsRecurrenceRule } from "@/types";
 import { generateIcsLine } from "./utils/addLine";
 import { generateIcsOptions } from "./utils/generateOptions";
 import { generateIcsWeekdayNumber } from "./weekdayNumber";
-import { generateIcsDate, generateIcsDateTime } from "./date";
+import { generateIcsDate, generateIcsUtcDateTime } from "./date";
 
 export const generateIcsRecurrenceRule = (value: IcsRecurrenceRule) => {
   let icsString = "";
@@ -36,7 +36,9 @@ export const generateIcsRecurrenceRule = (value: IcsRecurrenceRule) => {
         value:
           value.until.type === "DATE"
             ? generateIcsDate(value.until.date)
-            : generateIcsDateTime(value.until.local?.date || value.until.date),
+            : generateIcsUtcDateTime(
+                value.until.local?.date || value.until.date
+              ),
       },
       value.workweekStart && { key: "WKST", value: value.workweekStart },
     ].filter((v) => !!v)

--- a/packages/ts-ics/src/lib/generate/timeStamp.ts
+++ b/packages/ts-ics/src/lib/generate/timeStamp.ts
@@ -13,6 +13,7 @@ import {
 
 type GenerateIcsTimeStampOptions = {
   timezones?: IcsTimezone[];
+  forceUtc?: boolean;
 };
 
 export const generateIcsTimeStamp = (
@@ -24,7 +25,8 @@ export const generateIcsTimeStamp = (
   const icsOptions = generateIcsOptions(
     [
       dateObject.type && { key: "VALUE", value: dateObject.type },
-      dateObject.local && { key: "TZID", value: dateObject.local.timezone },
+      dateObject.local &&
+        !options?.forceUtc && { key: "TZID", value: dateObject.local.timezone },
       ...lineOptions,
     ].filter((v) => !!v)
   );
@@ -32,7 +34,7 @@ export const generateIcsTimeStamp = (
   const value =
     dateObject.type === "DATE"
       ? generateIcsDate(dateObject.date)
-      : dateObject.local
+      : dateObject.local && !options?.forceUtc
       ? generateIcsLocalDateTime(dateObject.local, options?.timezones)
       : generateIcsUtcDateTime(dateObject.date);
 

--- a/packages/ts-ics/src/lib/generate/timeStamp.ts
+++ b/packages/ts-ics/src/lib/generate/timeStamp.ts
@@ -1,29 +1,40 @@
-import type { IcsDateObject } from "@/types";
+import type { IcsDateObject, IcsTimezone } from "@/types";
 
-import { generateIcsDate, generateIcsDateTime } from "./date";
+import {
+  generateIcsDate,
+  generateIcsLocalDateTime,
+  generateIcsUtcDateTime,
+} from "./date";
 import { generateIcsLine } from "./utils/addLine";
 import {
   generateIcsOptions,
   type GenerateIcsOptionsProps,
 } from "./utils/generateOptions";
 
+type GenerateIcsTimeStampOptions = {
+  timezones?: IcsTimezone[];
+};
+
 export const generateIcsTimeStamp = (
   icsKey: string,
   dateObject: IcsDateObject,
-  options: GenerateIcsOptionsProps = []
+  lineOptions: GenerateIcsOptionsProps = [],
+  options?: GenerateIcsTimeStampOptions
 ) => {
-  const value =
-    dateObject.type === "DATE"
-      ? generateIcsDate(dateObject.date)
-      : generateIcsDateTime(dateObject.local?.date || dateObject.date);
-
   const icsOptions = generateIcsOptions(
     [
       dateObject.type && { key: "VALUE", value: dateObject.type },
       dateObject.local && { key: "TZID", value: dateObject.local.timezone },
-      ...options,
+      ...lineOptions,
     ].filter((v) => !!v)
   );
+
+  const value =
+    dateObject.type === "DATE"
+      ? generateIcsDate(dateObject.date)
+      : dateObject.local
+      ? generateIcsLocalDateTime(dateObject.local, options?.timezones)
+      : generateIcsUtcDateTime(dateObject.date);
 
   return generateIcsLine(icsKey, value, icsOptions);
 };

--- a/packages/ts-ics/src/lib/generate/timezone.ts
+++ b/packages/ts-ics/src/lib/generate/timezone.ts
@@ -1,7 +1,7 @@
 import { VTIMEZONE_TO_KEYS } from "@/constants/keys/timezone";
 import type { IcsTimezone } from "@/types/timezone";
 
-import { generateIcsDateTime } from "./date";
+import { generateIcsUtcDateTime } from "./date";
 import { generateIcsTimezoneProp } from "./timezoneProp";
 import {
   generateIcsLine,
@@ -43,7 +43,10 @@ export const generateIcsTimezone = <T extends NonStandardValuesGeneric>(
     const value = timezone[key];
 
     if (key === "lastModified") {
-      icsString += generateIcsLine(icsKey, generateIcsDateTime(value as Date));
+      icsString += generateIcsLine(
+        icsKey,
+        generateIcsUtcDateTime(value as Date)
+      );
       return;
     }
 

--- a/packages/ts-ics/src/lib/generate/timezoneProp.ts
+++ b/packages/ts-ics/src/lib/generate/timezoneProp.ts
@@ -2,7 +2,7 @@ import { VTIMEZONE_PROP_TO_KEYS } from "@/constants/keys/timezoneProp";
 import type { IcsDateObject, IcsRecurrenceRule } from "@/types";
 import type { IcsTimezoneProp } from "@/types/timezoneProp";
 
-import { generateIcsDateTime } from "./date";
+import { generateIcsUtcDateTime } from "./date";
 import { generateIcsRecurrenceRule } from "./recurrenceRule";
 import { generateIcsTimeStamp } from "./timeStamp";
 import {
@@ -45,7 +45,10 @@ export const generateIcsTimezoneProp = <T extends NonStandardValuesGeneric>(
     const value = timezoneProp[key];
 
     if (key === "start") {
-      icsString += generateIcsLine(icsKey, generateIcsDateTime(value as Date));
+      icsString += generateIcsLine(
+        icsKey,
+        generateIcsUtcDateTime(value as Date)
+      );
       return;
     }
 

--- a/packages/ts-ics/src/lib/generate/trigger.ts
+++ b/packages/ts-ics/src/lib/generate/trigger.ts
@@ -1,9 +1,9 @@
-import type { IcsDateObject, IcsDuration, IcsTrigger } from "@/types";
+import type { IcsTrigger } from "@/types";
 
 import { generateIcsDuration } from "./duration";
-import { generateIcsTimeStamp } from "./timeStamp";
 import { generateIcsLine } from "./utils/addLine";
 import { generateIcsOptions } from "./utils/generateOptions";
+import { generateIcsUtcDateTime } from "./date";
 
 export const generateIcsTrigger = (trigger: IcsTrigger) => {
   const options = generateIcsOptions(
@@ -16,13 +16,16 @@ export const generateIcsTrigger = (trigger: IcsTrigger) => {
   );
 
   if (trigger.type === "absolute") {
-    return generateIcsTimeStamp("TRIGGER", trigger.value as IcsDateObject);
+    return generateIcsLine(
+      "TRIGGER",
+      generateIcsUtcDateTime(trigger.value?.date)
+    );
   }
 
   if (trigger.type === "relative") {
     return generateIcsLine(
       "TRIGGER",
-      generateIcsDuration(trigger.value as IcsDuration),
+      generateIcsDuration(trigger.value),
       options
     );
   }

--- a/packages/ts-ics/tests/generate/event.test.ts
+++ b/packages/ts-ics/tests/generate/event.test.ts
@@ -41,3 +41,58 @@ it("Generate event - handle RECURRENCE-ID correctly gh#159", () => {
     "RECURRENCE-ID;RANGE=THISANDFUTURE:20250220T000000Z"
   );
 });
+
+describe("Ensure Stamp is always generated in UTC Format", () => {
+  // DTSTAMP MUST be in UTC - https://www.rfc-editor.org/rfc/rfc5545#section-3.8.7.2
+  const utcDate = new Date("2025-02-20T00:00:00Z");
+  const localDate = new Date("2025-02-20T12:00:00+0200");
+
+  it("utc date", () => {
+    const event: IcsEvent = {
+      stamp: { date: utcDate },
+      start: { date: utcDate },
+      summary: "123",
+      uid: "123",
+      duration: { days: 2 },
+    };
+
+    const eventString = generateIcsEvent(event);
+
+    expect(eventString).toContain("DTSTAMP:20250220T000000Z");
+  });
+
+  it("local date", () => {
+    const event: IcsEvent = {
+      stamp: { date: localDate },
+      start: { date: utcDate },
+      summary: "123",
+      uid: "123",
+      duration: { days: 2 },
+    };
+
+    const eventString = generateIcsEvent(event);
+
+    expect(eventString).toContain("DTSTAMP:20250220T100000Z");
+  });
+
+  it("specified in local date", () => {
+    const event: IcsEvent = {
+      stamp: {
+        date: utcDate,
+        local: {
+          date: localDate,
+          timezone: "Europe/Berlin",
+          tzoffset: "+0200",
+        },
+      },
+      start: { date: utcDate },
+      summary: "123",
+      uid: "123",
+      duration: { days: 2 },
+    };
+
+    const eventString = generateIcsEvent(event);
+
+    expect(eventString).toContain("DTSTAMP:20250220T000000Z");
+  });
+});

--- a/packages/ts-ics/tests/parse/date.test.ts
+++ b/packages/ts-ics/tests/parse/date.test.ts
@@ -1,4 +1,4 @@
-import { generateIcsDateTime } from "@/lib";
+import { generateIcsUtcDateTime } from "@/lib";
 import { convertIcsDate, convertIcsDateTime } from "@/lib/parse/date";
 import { setMilliseconds } from "date-fns";
 
@@ -17,7 +17,7 @@ it("Test Ics Date Parse", async () => {
 it("Strip Milliseconds - Milliseconds are not allowed in Ics", async () => {
   const date = new Date("2023-01-18T07:30:00.123Z");
 
-  const icsDate = generateIcsDateTime(date);
+  const icsDate = generateIcsUtcDateTime(date);
 
   expect(convertIcsDateTime(undefined, { value: icsDate })).toEqual(
     setMilliseconds(date, 0)


### PR DESCRIPTION
This fixes #165 where "Z" is stripped from the date string. Also, if the date in the local object is provided in a different timezone, it is corrected to the provided timezone with IANA fallback.

I am also thinking about removing the date value in the local object and keeping only the base date value instead. This would mean that when parsing a date-time value, the date value would not always be in UTC form.