### PR TITLE
fix: nested non-standard fields

### DIFF
--- a/packages/ts-ics/src/lib/parse/calendar.ts
+++ b/packages/ts-ics/src/lib/parse/calendar.ts
@@ -76,6 +76,7 @@ export const convertIcsCalendar = <T extends NonStandardValuesGeneric>(
     const events = eventStrings.map((eventString) =>
       convertIcsEvent(undefined, eventString, {
         timezones: calendar.timezones,
+        nonStandard: options?.nonStandard,
       })
     );
     calendar.events = events;

--- a/packages/ts-ics/tests/parse/calendar.test.ts
+++ b/packages/ts-ics/tests/parse/calendar.test.ts
@@ -238,3 +238,33 @@ it("Test non standard value", async () => {
 
   expect(calendar.nonStandard?.wtf).toBe(nonStandardValue);
 });
+
+it("should parse a calendar with a non-standard event field but fail the test", async () => {
+  const nonStandardValue = "yeah";
+
+  const calendarString = icsTestData([
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Test//NonStandard Event//EN",
+    "BEGIN:VEVENT",
+    "UID:test-non-standard-event@example.com",
+    "DTSTAMP:20240101T000000Z",
+    "DTSTART:20240101T100000Z",
+    "SUMMARY:Event with Non-Standard Field",
+    `X-WTF:${nonStandardValue}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ]);
+
+  const calendar = convertIcsCalendar(undefined, calendarString, {
+    nonStandard: {
+      wtf: {
+        name: "X-WTF",
+        convert: (line) => line.value,
+        schema: z.string(),
+      },
+    },
+  });
+
+  expect(calendar.events?.[0]?.nonStandard?.wtf).toBe(nonStandardValue);
+});


### PR DESCRIPTION
First off, huge thanks for this brilliant library. It saved me weeks of slogging through ICS parsing, so I had to give back.

The issue I fixed is that as of `2.0.3`, events with non-standard fields inside a calendar aren’t parsed properly — only top-level fields are handled:
```
BEGIN:VCALENDAR
X-WR-CALNAME:Content-Kalender               # ← gets picked up by `convertIcsCalendar` 🙏
BEGIN:VEVENT
X-APPLE-CREATOR-IDENTITY:com.apple.calendar # ← gets silently skipped by `convertIcsCalendar` 😭
END:VALARM
END:VEVENT
END:VCALENDAR
```

The fix is basically a one-liner, and now extended fields on both the calendar and its events are handled.

I made the `nonStandard` option shared between the calendar and event parsers — felt more intuitive that way. But if you see it differently, happy to iterate.

Cheers.
