### PR TITLE
Fix missing SEQUENCE key

### DIFF
--- a/packages/ts-ics/src/lib/generate/event.ts
+++ b/packages/ts-ics/src/lib/generate/event.ts
@@ -108,7 +108,7 @@ export const generateIcsEvent = <T extends NonStandardValuesGeneric>(
     }
 
     if (key === "sequence") {
-      icsString += (value as number).toString();
+      icsString += generateIcsLine(icsKey, (value as number).toString());
       return;
     }
 


### PR DESCRIPTION
Hello !

Just noticed what I think is a bug when using the `SEQUENCE` attribute when creating an event.

When passing in following data:
```js
{
    duration: {hours: 1},
    location: 'MyLocation',
    sequence: 0,
    start: {date: new Date('20250501')},
    stamp: {date: new Date(Date.now())},
    status: 'CONFIRMED',
    summary: `Appointment at MyLocation`,
    uid: 'myUUID',
}
```
This results in in the following output:
```
BEGIN:VEVENT
LOCATION:MyLocation
0DTSTART:20250423T072000Z
DTSTAMP:20250422T100036Z
STATUS:CONFIRMED
SUMMARY:Appointment at MyLocation
UID:myUUID
DURATION:PT1H
END:VEVENT
```

As you can see, the `0` from the Sequence is printed but the Key is missing (`SEQUENCE:`).

I think it is just a missing `generateIcsLine` call, which I added to fix the problem.