### PR TITLE
fix: find active VTIMEZONE observance instead of using last element

### DIFF
--- a/packages/ts-ics/src/utils/timezone/getTimezone.ts
+++ b/packages/ts-ics/src/utils/timezone/getTimezone.ts
@@ -36,10 +36,26 @@ export const getTimezoneObjectOffset = (
       }
     }
 
-    const icsOffset = sortedProps[sortedProps.length - 1].offsetTo;
-    const offset = icsOffset.length > 5 ? icsOffset.substring(0, 5) : icsOffset;
+    // Find the most recent observance that is still active for the given date
+    for (let i = sortedProps.length - 1; i >= 0; i -= 1) {
+      const prop = sortedProps[i];
 
-    return { offset, milliseconds: timeZoneOffsetToMilliseconds(offset) };
+      // Skip if this observance hasn't started yet
+      if (date < prop.start) continue;
+
+      // Check if this observance has ended (via RRULE UNTIL or RDATE)
+      const until = prop.recurrenceRule?.until?.date;
+      const rdate = prop.recurrenceDate?.date;
+
+      // Skip if this observance has already ended
+      if (until && date > until) continue;
+      if (rdate && date > rdate) continue;
+
+      // Found the correct active observance
+      const icsOffset = prop.offsetTo;
+      const offset = icsOffset.length > 5 ? icsOffset.substring(0, 5) : icsOffset;
+      return { offset, milliseconds: timeZoneOffsetToMilliseconds(offset) };
+    }
   }
 
   const ianaTimezone = getOffsetFromTimezoneId(tzid, date);

--- a/packages/ts-ics/tests/parse/timezone.test.ts
+++ b/packages/ts-ics/tests/parse/timezone.test.ts
@@ -215,3 +215,61 @@ it("Test non standard value", async () => {
 
 	expect(timeZone.nonStandard?.wtf).toBe(nonStandardValue);
 });
+
+it('should resolve correct offset (+0900) when VTIMEZONE contains historical DST observances (regression for #246)', async () => {
+  const icsString = icsTestData([
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    'DTSTART;TZID=Asia/Tokyo:20260527T125500',
+    'DTEND;TZID=Asia/Tokyo:20260527T160500',
+    'UID:test-jst-regression',
+    'END:VEVENT',
+    'BEGIN:VTIMEZONE',
+    'TZID:Asia/Tokyo',
+    'BEGIN:STANDARD',
+    'DTSTART:18880101T001859',
+    'RDATE:18880101T001859',
+    'TZNAME:JST',
+    'TZOFFSETFROM:+091859',
+    'TZOFFSETTO:+0900',
+    'END:STANDARD',
+    'BEGIN:DAYLIGHT',
+    'DTSTART:19480501T235959',
+    'RDATE:19480501T235959',
+    'RDATE:19490402T235959',
+    'TZNAME:JDT',
+    'TZOFFSETFROM:+0900',
+    'TZOFFSETTO:+1000',
+    'END:DAYLIGHT',
+    'BEGIN:STANDARD',
+    'DTSTART:19480912T010000',
+    'RRULE:FREQ=YEARLY;UNTIL=19510908T150000Z;BYMONTH=9;BYMONTHDAY=9,10,11,12,13,14,15;BYDAY=SU',
+    'TZNAME:JST',
+    'TZOFFSETFROM:+1000',
+    'TZOFFSETTO:+0900',
+    'END:STANDARD',
+    'BEGIN:DAYLIGHT',
+    'DTSTART:19500506T235959',
+    'RRULE:FREQ=YEARLY;UNTIL=19510505T145959Z;BYMONTH=5;BYDAY=1SA',
+    'TZNAME:JDT',
+    'TZOFFSETFROM:+0900',
+    'TZOFFSETTO:+1000',
+    'END:DAYLIGHT',
+    'END:VTIMEZONE',
+    'END:VCALENDAR',
+  ]);
+
+  const { convertIcsCalendar } = await import('@/lib');
+  const cal = convertIcsCalendar(undefined, icsString);
+
+  // Regression: historical JDT (+1000) should NOT apply to 2026 dates
+  expect(cal.events).toHaveLength(1);
+  expect(cal.events[0].start.date.toISOString()).toBe('2026-05-27T03:55:00.000Z');
+  expect(cal.events[0].end.date.toISOString()).toBe('2026-05-27T07:05:00.000Z');
+  expect(cal.events[0].start.local).toEqual({
+    date: expect.any(Date),
+    timezone: 'Asia/Tokyo',
+    tzoffset: '+0900',
+  });
+});


### PR DESCRIPTION
## Problem

In `getTimezoneObjectOffset`, when the target date is after all observance start times, the function was unconditionally returning `sortedProps[sortedProps.length - 1].offsetTo`. This caused historical DST observances (e.g., Japan JDT from 1948-1951, offset +1000) to be incorrectly applied to current dates (2026).

## Root Cause

The VTIMEZONE for `Asia/Tokyo` generated by iCloud includes historical observances:
- STANDARD (1888, no end) → offsetTo: +0900
- DAYLIGHT (1948, RDATE only) → offsetTo: +1000  
- STANDARD (1948, UNTIL=1951) → offsetTo: +0900
- DAYLIGHT (1950, UNTIL=1951) → offsetTo: +1000

Since the last observance (DAYLIGHT with UNTIL=1951) has ended before 2026, it should not be selected. However, the original code unconditionally returned its `offsetTo`.

## Solution

After the forward loop, iterate backwards through `sortedProps` to find the most recent observance that:
1. Has already started (`date >= prop.start`)
2. Has not yet ended (no `recurrenceRule.until`, or `date <= until`; also checks `recurrenceDate` for RDATE-only observances)

If no active observance is found, fall through to the existing IANA timezone resolution (`getOffsetFromTimezoneId`).

## Changes

Modified `packages/ts-ics/src/utils/timezone/getTimezone.ts`:

- Replaced unconditional `sortedProps[last].offsetTo` with a backward search for the last active observance
- Added checks for `recurrenceRule.until` and `recurrenceDate` to determine if an observance has ended

## Testing

- Japan historical JDT (1948-1951): correctly returns +0900 for 2026 dates (fixes the bug)
- Europe/Berlin with current DST: verified correct behavior for both summer (+0200) and winter (+0100)
- Existing test suite: no regressions introduced

## Related Issue

Closes #246
